### PR TITLE
Dev into stage (#16)

### DIFF
--- a/mountainscholar/app/admin/admin-sidebar/admin-sidebar.component.ts
+++ b/mountainscholar/app/admin/admin-sidebar/admin-sidebar.component.ts
@@ -16,7 +16,6 @@ import { BrowserOnlyPipe } from '../../../../../app/shared/utils/browser-only.pi
   //templateUrl: '../../../../../app/admin/admin-sidebar/admin-sidebar.component.html',
   // styleUrls: ['./admin-sidebar.component.scss']
   styleUrls: ['../../../../../app/admin/admin-sidebar/admin-sidebar.component.scss'],
-  standalone: true,
   imports: [
     AsyncPipe,
     BrowserOnlyPipe,

--- a/mountainscholar/app/footer/footer.component.ts
+++ b/mountainscholar/app/footer/footer.component.ts
@@ -14,7 +14,6 @@ import { FooterComponent as BaseComponent } from '../../../../app/footer/footer.
   styleUrls: ['../../../../app/footer/footer.component.scss'],
   templateUrl: './footer.component.html',
   //templateUrl: '../../../../app/footer/footer.component.html',
-  standalone: true,
   imports: [
     AsyncPipe,
     DatePipe,

--- a/mountainscholar/app/header/header.component.ts
+++ b/mountainscholar/app/header/header.component.ts
@@ -17,7 +17,6 @@ import { ImpersonateNavbarComponent } from '../../../../app/shared/impersonate-n
   styleUrls: ['../../../../app/header/header.component.scss'],
   templateUrl: './header.component.html',
   //templateUrl: '../../../../app/header/header.component.html',
-  standalone: true,
   imports: [
     AsyncPipe,
     ContextHelpToggleComponent,

--- a/mountainscholar/app/home-page/home-news/home-news.component.ts
+++ b/mountainscholar/app/home-page/home-news/home-news.component.ts
@@ -8,7 +8,6 @@ import { HomeNewsComponent as BaseComponent } from '../../../../../app/home-page
   styleUrls: ['../../../../../app/home-page/home-news/home-news.component.scss'],
   templateUrl: './home-news.component.html',
   //templateUrl: '../../../../../app/home-page/home-news/home-news.component.html',
-  standalone: true,
 })
 export class HomeNewsComponent extends BaseComponent {
 }

--- a/mountainscholar/app/item-page/simple/field-components/file-section/file-section.component.ts
+++ b/mountainscholar/app/item-page/simple/field-components/file-section/file-section.component.ts
@@ -15,7 +15,6 @@ import { VarDirective } from '../../../../../../../app/shared/utils/var.directiv
   templateUrl: './file-section.component.html',
   //templateUrl: '../../../../../../../app/item-page/simple/field-components/file-section/file-section.component.html',
   animations: [slideSidebarPadding],
-  standalone: true,
   imports: [
     CommonModule,
     FileSizePipe,

--- a/mountainscholar/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
+++ b/mountainscholar/app/item-page/simple/item-types/untyped-item/untyped-item.component.html
@@ -19,7 +19,7 @@
   <ds-dso-edit-menu></ds-dso-edit-menu>
 </div>
 <div class="row">
-  <div class="col-xs-12 col-md-4">
+  <div class="col-12 col-md-4">
     @if (!(mediaViewer.image || mediaViewer.video)) {
       <ds-metadata-field-wrapper [hideIfNoTextContent]="false">
         <ds-thumbnail [thumbnail]="object?.thumbnail | async"></ds-thumbnail>
@@ -56,7 +56,7 @@
       [label]="'item.page.volume-title'">
     </ds-generic-item-page-field>
   </div>
-  <div class="col-xs-12 col-md-6">
+  <div class="col-12 col-md-6">
     <ds-item-page-abstract-field [item]="object"></ds-item-page-abstract-field>
     <ds-generic-item-page-field [item]="object"
       [fields]="['dc.description']"

--- a/mountainscholar/app/item-page/simple/item-types/untyped-item/untyped-item.component.ts
+++ b/mountainscholar/app/item-page/simple/item-types/untyped-item/untyped-item.component.ts
@@ -39,7 +39,6 @@ import { ThemedThumbnailComponent } from '../../../../../../../app/thumbnail/the
   // templateUrl:
   //  '../../../../../../../app/item-page/simple/item-types/untyped-item/untyped-item.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  standalone: true,
   imports: [
     AsyncPipe,
     CollectionsComponent,

--- a/mountainscholar/app/login-page/login-page.component.ts
+++ b/mountainscholar/app/login-page/login-page.component.ts
@@ -10,7 +10,6 @@ import { LoginPageComponent as BaseComponent } from '../../../../app/login-page/
   styleUrls: ['../../../../app/login-page/login-page.component.scss'],
   templateUrl: './login-page.component.html',
   //templateUrl: '../../../../app/login-page/login-page.component.html',
-  standalone: true,
   imports: [
     ThemedLogInComponent,
     TranslateModule,

--- a/mountainscholar/app/request-copy/email-request-copy/email-request-copy.component.ts
+++ b/mountainscholar/app/request-copy/email-request-copy/email-request-copy.component.ts
@@ -16,7 +16,6 @@ import { BtnDisabledDirective } from '../../../../../app/shared/btn-disabled.dir
   styleUrls: ['../../../../../app/request-copy/email-request-copy/email-request-copy.component.scss'],
   templateUrl: './email-request-copy.component.html',
   //templateUrl: '../../../../../app/request-copy/email-request-copy/email-request-copy.component.html',
-  standalone: true,
   imports: [
     AsyncPipe,
     BtnDisabledDirective,

--- a/mountainscholar/app/shared/file-download-link/file-download-link.component.ts
+++ b/mountainscholar/app/shared/file-download-link/file-download-link.component.ts
@@ -16,7 +16,6 @@ import { FileDownloadLinkComponent as BaseComponent } from '../../../../../app/s
   templateUrl: '../../../../../app/shared/file-download-link/file-download-link.component.html',
   styleUrls: ['./file-download-link.component.scss'],
   // styleUrls: ['../../../../../app/shared/file-download-link/file-download-link.component.scss'],
-  standalone: true,
   imports: [
     AsyncPipe,
     NgClass,
@@ -28,4 +27,3 @@ import { FileDownloadLinkComponent as BaseComponent } from '../../../../../app/s
 })
 export class FileDownloadLinkComponent extends BaseComponent {
 }
-

--- a/mountainscholar/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.ts
+++ b/mountainscholar/app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.ts
@@ -23,7 +23,6 @@ import { ThemedThumbnailComponent } from '../../../../../../../../../app/thumbna
   styleUrls: ['../../../../../../../../../app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.scss'],
   templateUrl: './item-search-result-list-element.component.html',
   // templateUrl: '../../../../../../../../../app/shared/object-list/search-result-list-element/item-search-result/item-types/item/item-search-result-list-element.component.html',
-  standalone: true,
   imports: [
     AsyncPipe,
     NgClass,

--- a/mountainscholar/styles/_global-styles.scss
+++ b/mountainscholar/styles/_global-styles.scss
@@ -3,10 +3,3 @@
 // imports the base global style
 @import '../../../styles/_global-styles.scss';
 
-// This rule fixes the bitstream download links to work within a list
-// and with the new access badges. If there isn't an access badge
-// the anchor link gets made inline so it goes on the first line of
-// the parent LI.
-li:not(:has(.access-status-list-element-badge)) a.d-block.no-block {
-  display: inline !important;
-}

--- a/mountainscholar/styles/_theme_sass_variable_overrides.scss
+++ b/mountainscholar/styles/_theme_sass_variable_overrides.scss
@@ -27,4 +27,6 @@
 // ) !default;
 //
 // $link-color: map-get($theme-colors, info) !default;
+@import '../../../styles/_variables.scss';
+
 $link-decoration: underline;

--- a/mountainscholar/styles/fix.css
+++ b/mountainscholar/styles/fix.css
@@ -1,0 +1,16 @@
+/*
+ * This rule fixes the bitstream download links to work within a list
+ * and with the new access badges. If there isn't an access badge
+ * the anchor link gets made inline so it goes on the first line of
+ * the parent LI.
+ *
+ * This is pulled out and injected as a separate css file because
+ * whatever updates happened to the Angular project the selector
+ * was causing the compiler to choke and not finish the build.
+ * Pulling it out like this and injecting it with the frontend's
+ * angular.json is a total hack, but is the only workaround I could
+ * find
+ */
+li:not(:has(.access-status-list-element-badge)) a.d-block.no-block {
+  display: inline !important;
+}

--- a/mountainscholar/styles/theme.scss
+++ b/mountainscholar/styles/theme.scss
@@ -1,7 +1,7 @@
 // This file combines the other scss files in to one. You usually shouldn't edit this file directly
 
-@import '../../../styles/_variables.scss';
 @import './_theme_sass_variable_overrides.scss';
+@import '../../../styles/_variables.scss';
 @import '../../../styles/_mixins.scss';
 @import '../../../styles/helpers/font_awesome_imports.scss';
 @import '../../../styles/_vendor.scss';


### PR DESCRIPTION
* chore: Update and align with DSpace 9.3 files

* fix: build failed based on theme.scss, try to sync with defaults)

* fix: Pull global styles into own CSS file

Some changes happened to the Angular project for the frontend and it would no longer get through pre-processing with the rule that is meant as an accessibility fix to put download links in a list, but still make them display appropriately in single-item situations.

This fix combines with a change to angular.json to inject this fix as a standalone CSS file. This is a total hacky workaround, but we need to keep this rule in place and its a pretty small (it is just 1 CSS rule)